### PR TITLE
Bugfix: Fix behavior when overriding defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,10 +224,10 @@ remain, later entries in the list override previous ones.
       },
       "aliases": {
         "attributes": {
-          "defaultNode": [ {"color": "gray"                            } ],
-          "defaultEdge": [ {"color": "gray"         , "thickness": 0.02} ],
-          "tau1"       : [ {"color": "tau1color"                       } ],
-          "tau1extn"   : [ {"color": "tau1extncolor"                   } ]
+          "defaultNode": [ {"color": "gray"         } ],
+          "defaultEdge": [ {"color": "gray"         } ],
+          "tau1"       : [ {"color": "tau1color"    } ],
+          "tau1extn"   : [ {"color": "tau1extncolor"} ]
         },
         "colors": {
           "gray"         : "#666"   ,

--- a/json/example3.json
+++ b/json/example3.json
@@ -8,10 +8,10 @@
     },
     "aliases": {
       "attributes": {
-        "defaultNode": [ {"color": "gray"                            } ],
-        "defaultEdge": [ {"color": "gray"         , "thickness": 0.02} ],
-        "tau1"       : [ {"color": "tau1color"                       } ],
-        "tau1extn"   : [ {"color": "tau1extncolor"                   } ]
+        "defaultNode": [ {"color": "gray"         } ],
+        "defaultEdge": [ {"color": "gray"         } ],
+        "tau1"       : [ {"color": "tau1color"    } ],
+        "tau1extn"   : [ {"color": "tau1extncolor"} ]
       },
       "colors": {
         "gray"         : "#666"   ,


### PR DESCRIPTION
We now only override the properties that are specified by the user. Previously, the defaults would be completely scrapped as soon as the user defined them.